### PR TITLE
Update dependencies for compatibility with Stripe 3.30

### DIFF
--- a/ecwid_api.gemspec
+++ b/ecwid_api.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 2.14", ">= 2.14.1"
 
   spec.add_dependency "faraday", "~> 0.10.0"
-  spec.add_dependency "faraday_middleware", "~> 0.9.1"
+  spec.add_dependency "faraday_middleware", "~> 0.10.1"
 end

--- a/ecwid_api.gemspec
+++ b/ecwid_api.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 0"
   spec.add_development_dependency "rspec", "~> 2.14", ">= 2.14.1"
 
-  spec.add_dependency "faraday", "~> 0.9.0"
+  spec.add_dependency "faraday", "~> 0.10.0"
   spec.add_dependency "faraday_middleware", "~> 0.9.1"
 end


### PR DESCRIPTION
This PR loosens the restriction on the Faraday dependencies to allow usage of version 3.30 of the Stripe gem, which requires Faraday 0.10.